### PR TITLE
gcc が必要になっていたので base image を変更

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11.3-slim-buster
+FROM python:3.11.3-buster
 
 RUN apt-get update && apt-get install -y graphviz fonts-ipafont-gothic && rm -rf /var/lib/apt/lists/*
 RUN pip install diagrams==0.23.3


### PR DESCRIPTION
```
#7 4.279   × Running setup.py install for typed-ast did not run successfully.
#7 4.279   │ exit code: 1
#7 4.279   ╰─> [23 lines of output]
#7 4.279       running install
#7 4.279       /usr/local/lib/python3.11/site-packages/setuptools/command/install.py:34: SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools.
#7 4.279         warnings.warn(
#7 4.279       running build
#7 4.279       running build_py
#7 4.279       creating build
#7 4.279       creating build/lib.linux-x86_64-cpython-311
#7 4.279       creating build/lib.linux-x86_64-cpython-311/typed_ast
#7 4.279       copying typed_ast/__init__.py -> build/lib.linux-x86_64-cpython-311/typed_ast
#7 4.279       copying typed_ast/ast3.py -> build/lib.linux-x86_64-cpython-311/typed_ast
#7 4.279       copying typed_ast/conversions.py -> build/lib.linux-x86_64-cpython-311/typed_ast
#7 4.279       copying typed_ast/ast27.py -> build/lib.linux-x86_64-cpython-311/typed_ast
#7 4.279       creating build/lib.linux-x86_64-cpython-311/typed_ast/tests
#7 4.279       copying ast3/tests/test_basics.py -> build/lib.linux-x86_64-cpython-311/typed_ast/tests
#7 4.279       running build_ext
#7 4.279       building '_ast27' extension
#7 4.279       creating build/temp.linux-x86_64-cpython-311
#7 4.279       creating build/temp.linux-x86_64-cpython-311/ast27
#7 4.279       creating build/temp.linux-x86_64-cpython-311/ast27/Custom
#7 4.279       creating build/temp.linux-x86_64-cpython-311/ast27/Parser
#7 4.279       creating build/temp.linux-x86_64-cpython-311/ast27/Python
#7 4.279       gcc -pthread -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -Iast27/Include -I/usr/local/include/python3.11 -c ast27/Custom/typed_ast.c -o build/temp.linux-x86_64-cpython-311/ast27/Custom/typed_ast.o
#7 4.279       error: command 'gcc' failed: No such file or directory
#7 4.279       [end of output]
```